### PR TITLE
Color status output

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -35,6 +35,19 @@ app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 
+
+# Custom Jinja filter to map task status to Bootstrap text color classes
+@app.template_filter('status_color')
+def status_color(status):
+    """Return Bootstrap color class for a task status."""
+    mapping = {
+        'SUCCESS': 'success',
+        'FAILURE': 'danger',
+        'RUNNING': 'primary',
+        'PENDING': 'secondary',
+    }
+    return mapping.get(status, 'secondary')
+
 # Setup Flask-Login
 login_manager = LoginManager()
 login_manager.login_view = 'login'

--- a/templates/_jobs_table.html
+++ b/templates/_jobs_table.html
@@ -13,7 +13,7 @@
       <td>{{ item.task.id }}</td>
       <td>{{ item.task.task_type }}</td>
       <td>{{ item.task.parameters }}</td>
-      <td>{{ item.task.status }}</td>
+      <td class="text-{{ item.task.status|status_color }}">{{ item.task.status }}</td>
       <td>{{ item.task.create_time }}</td>
       <td>
         {% for filename in item.files %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -41,7 +41,7 @@
       <td>{{ t.id }}</td>
       <td>{{ t.user.username }}</td>
       <td>{{ t.task_type }}</td>
-      <td>{{ t.status }}</td>
+      <td class="text-{{ t.status|status_color }}">{{ t.status }}</td>
       <td>{{ t.create_time }}</td>
       <td>{{ 'Yes' if t.archived else 'No' }}</td>
       <td>


### PR DESCRIPTION
## Summary
- highlight task status values using Bootstrap text color classes
- add a helper `status_color` Jinja filter

## Testing
- `python -m py_compile flask_app.py tasks.py models.py celery_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e1481d0dc832aaec8573a5fec5124