### PR TITLE
Add individual pages for fractal and primes apps

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -21,16 +21,7 @@
 <h2>Submit a new task</h2>
 <div class="mb-4">
   {% for key, cfg in configs.items() %}
-  <form action="{{ url_for('submit_task', task_type=key) }}" method="post" class="d-inline-block me-3">
-    <div class="input-group">
-      {% if key == 'fractal' %}
-      <input type="number" name="depth" class="form-control" min="0" placeholder="Depth" required>
-      {% elif key == 'primes' %}
-      <input type="number" name="n" class="form-control" min="2" placeholder="N" required>
-      {% endif %}
-      <button class="btn btn-primary" type="submit">Submit {{ key|capitalize }}</button>
-    </div>
-  </form>
+  <a class="btn btn-primary me-3" href="{{ url_for('task_detail', task_type=key) }}">{{ key|capitalize }} App</a>
   {% endfor %}
 </div>
 <div id="jobs-section">

--- a/templates/task.html
+++ b/templates/task.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}{{ task_type|capitalize }} App{% endblock %}
+{% block content %}
+<h1 class="mb-4">{{ task_type|capitalize }} Application</h1>
+<p>{{ description }}</p>
+<form action="{{ url_for('submit_task', task_type=task_type) }}" method="post" class="mt-3">
+  <div class="mb-3">
+    {% if task_type == 'fractal' %}
+    <label class="form-label">Depth</label>
+    <input type="number" name="depth" class="form-control" min="0" placeholder="Depth" required>
+    {% elif task_type == 'primes' %}
+    <label class="form-label">N</label>
+    <input type="number" name="n" class="form-control" min="2" placeholder="N" required>
+    {% endif %}
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add helper to read docstring from task scripts
- create route `/task/<task_type>` with dedicated page
- update dashboard to link to each app instead of showing forms
- new template `task.html`

## Testing
- `python -m py_compile flask_app.py tasks.py models.py scripts/run_fractal.py scripts/run_primes.py`
- *(fails: `ModuleNotFoundError: No module named 'flask'` when trying to run server)*

------
https://chatgpt.com/codex/tasks/task_e_684e18101c6c832aaedfc6326ef23fa2