### PR TITLE
Split admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ flask-task-platform/
 ├── templates/         # HTML 範本
 │   ├── login.html
 │   ├── dashboard.html
-│   └── admin.html
+│   ├── admin_tasks.html
+│   └── admin_users.html
 └── static/            # 靜態資源
     └── css/
         └── style.css

--- a/flask_app.py
+++ b/flask_app.py
@@ -209,6 +209,14 @@ def download_file(task_id, filename):
 @app.route('/admin')
 @login_required
 def admin():
+    """Redirect /admin to the task statistics page."""
+    return redirect(url_for('admin_tasks'))
+
+
+@app.route('/admin/tasks')
+@login_required
+def admin_tasks():
+    """Display task statistics and all submitted tasks."""
     if not current_user.is_admin:
         abort(403)
     q = request.args.get('q', '').strip()
@@ -222,7 +230,6 @@ def admin():
             or_(User.username.ilike(f'%{q}%'), *filters)
         )
     tasks_query = tasks_query.order_by(Task.create_time.desc()).all()
-    users = User.query.all()
     stats = {}
     for t in Task.query.all():
         entry = stats.setdefault(t.task_type, {'count': 0, 'success': 0, 'total_time': 0.0})
@@ -235,18 +242,25 @@ def admin():
         count = data['count']
         data['success_rate'] = round((data['success'] / count * 100) if count else 0, 2)
         data['avg_time'] = round((data['total_time'] / count) if count else 0, 2)
+    return render_template(
+        'admin_tasks.html', stats=stats, tasks=tasks_query, q=q
+    )
 
-    # Per-user statistics
+
+@app.route('/admin/users')
+@login_required
+def admin_users():
+    """Display the user management page with per-user statistics."""
+    if not current_user.is_admin:
+        abort(403)
+    users = User.query.all()
     user_stats = {}
     for u in users:
         total = len(u.tasks)
         success = sum(1 for t in u.tasks if t.status == 'SUCCESS')
         rate = round((success / total * 100) if total else 0, 2)
         user_stats[u.id] = {'total': total, 'success_rate': rate}
-    return render_template(
-        'admin.html', users=users, stats=stats,
-        tasks=tasks_query, q=q, user_stats=user_stats
-    )
+    return render_template('admin_users.html', users=users, user_stats=user_stats)
 
 
 @app.route('/admin/archive/<int:task_id>', methods=['POST'])
@@ -257,7 +271,7 @@ def archive_task(task_id):
     task = Task.query.get_or_404(task_id)
     task.archived = True
     db.session.commit()
-    return redirect(url_for('admin'))
+    return redirect(url_for('admin_tasks'))
 
 
 @app.route('/admin/users/add', methods=['POST'])
@@ -275,10 +289,10 @@ def add_user():
     is_admin_flag = bool(request.form.get('is_admin'))
     if not username or not password:
         flash('Username and password are required')
-        return redirect(url_for('admin'))
+        return redirect(url_for('admin_users'))
     if User.query.filter_by(username=username).first():
         flash('Username already exists')
-        return redirect(url_for('admin'))
+        return redirect(url_for('admin_users'))
     user = User(
         username=username,
         password_hash=generate_password_hash(password),
@@ -291,7 +305,7 @@ def add_user():
     db.session.add(user)
     db.session.commit()
     flash('User added')
-    return redirect(url_for('admin'))
+    return redirect(url_for('admin_users'))
 
 
 @app.route('/admin/users/edit/<int:user_id>', methods=['GET', 'POST'])
@@ -313,7 +327,7 @@ def edit_user(user_id):
         user.is_admin = bool(request.form.get('is_admin'))
         db.session.commit()
         flash('User updated')
-        return redirect(url_for('admin'))
+        return redirect(url_for('admin_users'))
     return render_template('edit_user.html', user=user)
 
 
@@ -326,11 +340,11 @@ def delete_user(user_id):
     user = User.query.get_or_404(user_id)
     if user.username == 'admin':
         flash('Cannot delete admin user')
-        return redirect(url_for('admin'))
+        return redirect(url_for('admin_users'))
     db.session.delete(user)
     db.session.commit()
     flash('User deleted')
-    return redirect(url_for('admin'))
+    return redirect(url_for('admin_users'))
 
 
 if __name__ == '__main__':

--- a/templates/_jobs_table.html
+++ b/templates/_jobs_table.html
@@ -25,5 +25,5 @@
   </tbody>
 </table>
 {% if current_user.is_admin %}
-<a class="btn btn-outline-secondary" href="{{ url_for('admin') }}">Admin Panel</a>
+<a class="btn btn-outline-secondary" href="{{ url_for('admin_tasks') }}">Admin Panel</a>
 {% endif %}

--- a/templates/admin_tasks.html
+++ b/templates/admin_tasks.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+{% block title %}Task Statistics{% endblock %}
+{% block content %}
+<h1 class="mb-4">Task Statistics</h1>
+<a class="btn btn-outline-primary mb-3" href="{{ url_for('admin_users') }}">Manage Users</a>
+<form method="get" action="{{ url_for('admin_tasks') }}" class="input-group mb-4">
+  <input type="text" name="q" class="form-control" placeholder="Search tasks" value="{{ q }}">
+  <button class="btn btn-primary" type="submit">Search</button>
+</form>
+<h2>Task Summary</h2>
+<table class="table table-bordered mb-4">
+  <thead><tr><th>Type</th><th>Count</th><th>Success Rate (%)</th><th>Avg Time (s)</th></tr></thead>
+  <tbody>
+    {% for type, stat in stats.items() %}
+    <tr>
+      <td>{{ type }}</td>
+      <td>{{ stat.count }}</td>
+      <td>{{ stat.success_rate }}</td>
+      <td>{{ stat.avg_time }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h2>All Tasks</h2>
+<table class="table table-bordered">
+  <thead><tr><th>ID</th><th>User</th><th>Type</th><th>Status</th><th>Submitted</th><th>Archived</th><th>Action</th></tr></thead>
+  <tbody>
+    {% for t in tasks %}
+    <tr>
+      <td>{{ t.id }}</td>
+      <td>{{ t.user.username }}</td>
+      <td>{{ t.task_type }}</td>
+      <td class="text-{{ t.status|status_color }}">{{ t.status }}</td>
+      <td>{{ t.create_time }}</td>
+      <td>{{ 'Yes' if t.archived else 'No' }}</td>
+      <td>
+        {% if not t.archived %}
+        <form method="post" action="{{ url_for('archive_task', task_id=t.id) }}" class="d-inline">
+          <button class="btn btn-sm btn-warning" type="submit">Archive</button>
+        </form>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,10 +1,8 @@
 {% extends 'base.html' %}
-{% block title %}Admin Panel{% endblock %}
+{% block title %}User Management{% endblock %}
 {% block content %}
-<form method="get" action="{{ url_for('admin') }}" class="input-group mb-4">
-  <input type="text" name="q" class="form-control" placeholder="Search tasks" value="{{ q }}">
-  <button class="btn btn-primary" type="submit">Search</button>
-</form>
+<h1 class="mb-4">User Management</h1>
+<a class="btn btn-outline-primary mb-3" href="{{ url_for('admin_tasks') }}">View Task Statistics</a>
 <h2>Users</h2>
 <table class="table table-bordered mb-4">
   <thead>
@@ -43,7 +41,6 @@
     {% endfor %}
   </tbody>
 </table>
-
 <h3>Add User</h3>
 <form method="post" action="{{ url_for('add_user') }}" class="mb-4">
   <div class="mb-3">
@@ -76,41 +73,4 @@
   </div>
   <button class="btn btn-primary" type="submit">Add</button>
 </form>
-<h2>Task Statistics</h2>
-<table class="table table-bordered mb-4">
-  <thead><tr><th>Type</th><th>Count</th><th>Success Rate (%)</th><th>Avg Time (s)</th></tr></thead>
-  <tbody>
-    {% for type, stat in stats.items() %}
-    <tr>
-      <td>{{ type }}</td>
-      <td>{{ stat.count }}</td>
-      <td>{{ stat.success_rate }}</td>
-      <td>{{ stat.avg_time }}</td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-<h2>All Tasks</h2>
-<table class="table table-bordered">
-  <thead><tr><th>ID</th><th>User</th><th>Type</th><th>Status</th><th>Submitted</th><th>Archived</th><th>Action</th></tr></thead>
-  <tbody>
-    {% for t in tasks %}
-    <tr>
-      <td>{{ t.id }}</td>
-      <td>{{ t.user.username }}</td>
-      <td>{{ t.task_type }}</td>
-      <td class="text-{{ t.status|status_color }}">{{ t.status }}</td>
-      <td>{{ t.create_time }}</td>
-      <td>{{ 'Yes' if t.archived else 'No' }}</td>
-      <td>
-        {% if not t.archived %}
-        <form method="post" action="{{ url_for('archive_task', task_id=t.id) }}" class="d-inline">
-          <button class="btn btn-sm btn-warning" type="submit">Archive</button>
-        </form>
-        {% endif %}
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
 {% endblock %}

--- a/templates/edit_user.html
+++ b/templates/edit_user.html
@@ -32,6 +32,6 @@
     <label class="form-check-label" for="is_admin">Admin</label>
   </div>
   <button class="btn btn-primary" type="submit">Save</button>
-  <a class="btn btn-secondary" href="{{ url_for('admin') }}">Cancel</a>
+  <a class="btn btn-secondary" href="{{ url_for('admin_users') }}">Cancel</a>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- split tasks statistics and user management into separate pages
- update all admin links

## Testing
- `python -m py_compile flask_app.py models.py tasks.py celery_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684e285331e0832a89d18da21874c18c