### PR TITLE
Fix BuildError due to incorrect login endpoint

### DIFF
--- a/flask_app.py
+++ b/flask_app.py
@@ -37,7 +37,7 @@ def status_color(status):
 
 # Setup Flask-Login
 login_manager = LoginManager()
-login_manager.login_view = 'login'
+login_manager.login_view = 'user.login'
 login_manager.init_app(app)
 
 

--- a/user_routes.py
+++ b/user_routes.py
@@ -19,7 +19,7 @@ user_bp = Blueprint('user', __name__)
 def index():
     if current_user.is_authenticated:
         return redirect(url_for('admin.admin_tasks')) if current_user.is_admin else redirect(url_for('user.dashboard'))
-    return redirect(url_for('login'))
+    return redirect(url_for('user.login'))
 
 
 @user_bp.route('/login', methods=['GET', 'POST'], endpoint='login')
@@ -41,7 +41,7 @@ def login():
 @login_required
 def logout():
     logout_user()
-    return redirect(url_for('login'))
+    return redirect(url_for('user.login'))
 
 
 @user_bp.route('/task/<task_type>', endpoint='task_detail')


### PR DESCRIPTION
## Summary
- use `user.login` endpoint when redirecting to login
- configure Flask-Login to use `user.login`

## Testing
- `python -m py_compile flask_app.py user_routes.py admin_routes.py models.py config_utils.py tasks.py celery_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7e7c6904832aa4e3cccdd9529bb4