### PR TITLE
Fix blueprint redirects

### DIFF
--- a/user_routes.py
+++ b/user_routes.py
@@ -114,7 +114,7 @@ def submit_task(task_type):
     db.session.commit()
     from tasks import run_task
     run_task.delay(new_task.id)
-    return redirect(url_for('dashboard'))
+    return redirect(url_for('user.dashboard'))
 
 
 @user_bp.route('/download/<int:task_id>/<path:filename>', endpoint='download_file')
@@ -142,4 +142,4 @@ def delete_task(task_id):
     task.result_files = json.dumps([])
     db.session.commit()
     flash('Task deleted')
-    return redirect(url_for('dashboard'))
+    return redirect(url_for('user.dashboard'))


### PR DESCRIPTION
## Summary
- fix redirects in `submit_task` and `delete_task`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7f326c44832aa0b8c9317fa7c53a