### PR TITLE
Fix submitted time display

### DIFF
--- a/models.py
+++ b/models.py
@@ -28,7 +28,8 @@ class Task(db.Model):
     parameters = db.Column(db.Text, nullable=False)
     status = db.Column(db.String(20), default='PENDING', nullable=False)
     result_files = db.Column(db.Text)
-    create_time = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    # Record creation time using the server's local timezone
+    create_time = db.Column(db.DateTime, default=datetime.now, nullable=False)
     start_time = db.Column(db.DateTime)
     end_time = db.Column(db.DateTime)
     archived = db.Column(db.Boolean, default=False, nullable=False)

--- a/tasks.py
+++ b/tasks.py
@@ -19,7 +19,8 @@ def run_task(self, task_id):
 
     # Update task status and start time
     task.status = 'RUNNING'
-    task.start_time = datetime.utcnow()
+    # Use server local time for consistency with displayed timestamps
+    task.start_time = datetime.now()
     db.session.commit()
 
     config = load_config()
@@ -55,5 +56,6 @@ def run_task(self, task_id):
     # Update task record with outcome and completion time
     task.status = status
     task.result_files = json.dumps(files)
-    task.end_time = datetime.utcnow()
+    # Record completion time in server local timezone
+    task.end_time = datetime.now()
     db.session.commit()

--- a/templates/_jobs_table.html
+++ b/templates/_jobs_table.html
@@ -14,7 +14,7 @@
       <td>{{ item.task.task_type }}</td>
       <td>{{ item.task.parameters }}</td>
       <td class="text-{{ item.task.status|status_color }}">{{ item.task.status }}</td>
-      <td>{{ item.task.create_time }}</td>
+      <td>{{ item.task.create_time.strftime('%Y-%m-%d %H:%M:%S') }}</td>
       <td>
         {% for filename in item.files %}
         <a class="link-primary" href="{{ url_for('user.download_file', task_id=item.task.id, filename=filename) }}">{{ filename }}</a><br>

--- a/templates/admin_tasks.html
+++ b/templates/admin_tasks.html
@@ -31,7 +31,7 @@
       <td>{{ t.user.username }}</td>
       <td>{{ t.task_type }}</td>
       <td class="text-{{ t.status|status_color }}">{{ t.status }}</td>
-      <td>{{ t.create_time }}</td>
+      <td>{{ t.create_time.strftime('%Y-%m-%d %H:%M:%S') }}</td>
       <td>{{ 'Yes' if t.archived else 'No' }}</td>
       <td>
         {% if not t.archived %}


### PR DESCRIPTION
## Summary
- show server-local creation time without microseconds in the dashboard
- use local time instead of UTC for task timestamps

## Testing
- `python -m py_compile models.py tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_684e8d24c36c832aa842a78d76c18304