### PR TITLE
Adjust S-parameter results display

### DIFF
--- a/scripts/run_sparams.py
+++ b/scripts/run_sparams.py
@@ -18,7 +18,8 @@ def main(input_file):
         for j in range(nports):
             fig, ax = plt.subplots()
             mag = 20 * np.log10(np.abs(ntwk.s[:, i, j]))
-            ax.plot(freqs, mag)
+            ax.plot(freqs, mag, color='red')
+            ax.grid(True)
             ax.set_xlabel('Frequency (Hz)')
             ax.set_ylabel('Magnitude (dB)')
             ax.set_title(f'S{i+1}{j+1}')
@@ -48,7 +49,7 @@ def main(input_file):
     for fname in plot_files:
         name = os.path.splitext(fname)[0]
         html_parts.append(
-            f'<div class="plot" data-title="{name}"><img src="{fname}" alt="{name}"><div>{name}</div></div>'
+            f'<div class="plot" data-title="{name}"><a href="{fname}" target="_blank"><img src="{fname}" alt="{name}"></a></div>'
         )
     html_parts.extend([
         '</div>',

--- a/templates/_jobs_table.html
+++ b/templates/_jobs_table.html
@@ -5,7 +5,7 @@
 <h2>Your tasks</h2>
 <table class="table table-striped">
   <thead>
-    <tr><th>ID</th><th>Type</th><th>Parameters</th><th>Status</th><th>Submitted</th><th>Result Files</th><th>Action</th></tr>
+    <tr><th>ID</th><th>Type</th><th>Parameters</th><th>Status</th><th>Submitted</th><th>Result</th><th>Action</th></tr>
   </thead>
   <tbody>
     {% for item in tasks %}
@@ -16,9 +16,13 @@
       <td class="text-{{ item.task.status|status_color }}">{{ item.task.status }}</td>
       <td>{{ item.task.create_time.strftime('%Y-%m-%d %H:%M:%S') }}</td>
       <td>
-        {% for filename in item.files %}
-        <a class="link-primary" href="{{ url_for('user.download_file', task_id=item.task.id, filename=filename) }}">{{ filename }}</a><br>
-        {% endfor %}
+        {% if item.html_file %}
+        <a class="link-primary" href="{{ url_for('user.view_file', task_id=item.task.id, filename=item.html_file) }}">{{ item.html_file }}</a>
+        {% else %}
+          {% for filename in item.files %}
+          <a class="link-primary" href="{{ url_for('user.download_file', task_id=item.task.id, filename=filename) }}">{{ filename }}</a><br>
+          {% endfor %}
+        {% endif %}
       </td>
       <td>
         <form method="post" action="{{ url_for('user.delete_task', task_id=item.task.id) }}" class="d-inline" onsubmit="return confirm('Delete this task?');">

--- a/user_routes.py
+++ b/user_routes.py
@@ -69,7 +69,8 @@ def dashboard():
     tasks_data = []
     for t in tasks_query:
         files = json.loads(t.result_files) if t.result_files else []
-        tasks_data.append({'task': t, 'files': files})
+        html_file = next((f for f in files if f.lower().endswith('.html')), None)
+        tasks_data.append({'task': t, 'files': files, 'html_file': html_file})
     return render_template('dashboard.html', tasks=tasks_data, configs=configs)
 
 
@@ -86,7 +87,8 @@ def dashboard_jobs():
     tasks_data = []
     for t in tasks_query:
         files = json.loads(t.result_files) if t.result_files else []
-        tasks_data.append({'task': t, 'files': files})
+        html_file = next((f for f in files if f.lower().endswith('.html')), None)
+        tasks_data.append({'task': t, 'files': files, 'html_file': html_file})
     return render_template('_jobs_table.html', tasks=tasks_data, configs=configs)
 
 
@@ -149,6 +151,16 @@ def download_file(task_id, filename):
         abort(403)
     directory = os.path.join(current_app.root_path, 'outputs', str(task_id))
     return send_from_directory(directory, filename, as_attachment=True)
+
+
+@user_bp.route('/view/<int:task_id>/<path:filename>', endpoint='view_file')
+@login_required
+def view_file(task_id, filename):
+    task = Task.query.get_or_404(task_id)
+    if task.user_id != current_user.id and not current_user.is_admin:
+        abort(403)
+    directory = os.path.join(current_app.root_path, 'outputs', str(task_id))
+    return send_from_directory(directory, filename, as_attachment=False)
 
 
 @user_bp.route('/delete/<int:task_id>', methods=['POST'], endpoint='delete_task')


### PR DESCRIPTION
## Summary
- rename "Result Files" column to "Result" on dashboard
- show only the HTML output for S-parameter tasks
- add route to view HTML directly without download
- remove visible S-parameter labels from index.html
- set S-parameter plot trace color to red and enable grid
- clicking a plot opens it in a new tab

## Testing
- `python -m py_compile scripts/run_sparams.py user_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_684ea1187f40832ab5259da23e8daf4b