### PR TITLE
Improve Sparams input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ celery -A celery_app.celery worker --loglevel=info --pool=solo
 ## 任務範例
 - **Fractal**：輸入深度 `--depth`，於 `outputs/<task_id>/fractal.png` 產生 Sierpinski 三角形圖檔，並將檔案列表與狀態寫入 `result.json`
 - **Primes**：輸入上限 `--n`，於 `outputs/<task_id>/result.csv` 輸出所有小於 N 的質數
-- **Sparams**：上傳 Touchstone 檔案 `--file`，於 `outputs/<task_id>/` 產生各組 S-parameter 圖檔與 `index.html`
+- **Sparams**：上傳任意埠數的 Touchstone 檔案（副檔名 `.sNp`，`N` 為任意整數），於 `outputs/<task_id>/` 產生各組 S-parameter 圖檔與 `index.html`
 
 ## 管理者功能
 - 設定管理者帳號：手動在資料庫中將 `User.is_admin` 欄位設為 `True`

--- a/templates/task.html
+++ b/templates/task.html
@@ -13,7 +13,7 @@
     <input type="number" name="n" class="form-control" min="2" placeholder="N" required>
     {% elif task_type == 'sparams' %}
     <label class="form-label">Touchstone File</label>
-    <input type="file" name="file" class="form-control" accept=".s1p,.s2p,.s3p,.s4p,.s5p,.s6p,.snp" required>
+      <input type="file" name="file" class="form-control" required>
     {% endif %}
   </div>
   <button type="submit" class="btn btn-primary">Submit</button>


### PR DESCRIPTION
## Summary
- relax file input validation for S-parameter jobs
- document that any `.sNp` Touchstone file is supported

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eaa2dab1c832a8b61298f17d7d11e