### PR TITLE
Improve Sparams input handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ celery -A celery_app.celery worker --loglevel=info --pool=solo
 ## 任務範例
 - **Fractal**：輸入深度 `--depth`，於 `outputs/<task_id>/fractal.png` 產生 Sierpinski 三角形圖檔，並將檔案列表與狀態寫入 `result.json`
 - **Primes**：輸入上限 `--n`，於 `outputs/<task_id>/result.csv` 輸出所有小於 N 的質數
-- **Sparams**：上傳 Touchstone 檔案 `--file`，於 `outputs/<task_id>/` 產生各組 S-parameter 圖檔與 `index.html`
+- **Sparams**：上傳任意埠數的 Touchstone 檔案（副檔名 `.sNp`，`N` 為任意整數），於 `outputs/<task_id>/` 產生各組 S-parameter 圖檔與 `index.html`
 
 ## 管理者功能
 - 設定管理者帳號：手動在資料庫中將 `User.is_admin` 欄位設為 `True`

--- a/scripts/run_sparams.py
+++ b/scripts/run_sparams.py
@@ -21,13 +21,14 @@ def main(input_file):
             ax.plot(freqs, mag, color='red')
             ax.set_xlabel('Frequency (Hz)')
             ax.set_ylabel('Magnitude (dB)')
-            ax.set_title(f'S{i+1}{j+1}')
+            title = f'S({i + 1},{j + 1})'
+            ax.set_title(title)
             ax.grid(True)
             fig.tight_layout()
-            fname = f'S{i+1}{j+1}.png'
+            fname = f'S_{i + 1}_{j + 1}.png'
             fig.savefig(fname)
             plt.close(fig)
-            plot_files.append(fname)
+            plot_files.append((fname, title))
 
     # Build simple HTML with 4-column grid and regex search
     html_parts = [
@@ -46,10 +47,10 @@ def main(input_file):
         '<input type="text" id="search" placeholder="Regex filter">',
         '<div class="grid" id="plots">'
     ]
-    for fname in plot_files:
+    for fname, title in plot_files:
         name = os.path.splitext(fname)[0]
         html_parts.append(
-            f'<div class="plot" data-title="{name}">'
+            f'<div class="plot" data-title="{title}">'
             f'<a href="{fname}" target="_blank"><img src="{fname}" alt="{name}"></a>'
             f'</div>'
         )
@@ -58,7 +59,8 @@ def main(input_file):
         '<script>',
         'const search=document.getElementById("search");',
         'search.addEventListener("input",()=>{',
-        ' const re=new RegExp(search.value||".","i");',
+        ' const escape=s=>s.replace(/[.*+?^${}()|[\\]\\\\]/g,"\\$&");',
+        ' const re=new RegExp(escape(search.value)||".","i");',
         ' document.querySelectorAll(".plot").forEach(p=>{',
         '  p.style.display=re.test(p.dataset.title)?"":"none";',
         ' });',

--- a/templates/task.html
+++ b/templates/task.html
@@ -13,7 +13,7 @@
     <input type="number" name="n" class="form-control" min="2" placeholder="N" required>
     {% elif task_type == 'sparams' %}
     <label class="form-label">Touchstone File</label>
-    <input type="file" name="file" class="form-control" accept=".s1p,.s2p,.s3p,.s4p,.s5p,.s6p,.snp" required>
+      <input type="file" name="file" class="form-control" required>
     {% endif %}
   </div>
   <button type="submit" class="btn btn-primary">Submit</button>


### PR DESCRIPTION
## Summary
- relax file input validation for S-parameter jobs
- document that any `.sNp` Touchstone file is supported
- disambiguate S-parameter plot titles by using `S(m,n)` format
- improve regex filtering to handle parentheses
- fix escaping for the regex filter

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eaa2dab1c832a8b61298f17d7d11e