### PR TITLE
Fix sparams output regex escaping

### DIFF
--- a/scripts/run_sparams.py
+++ b/scripts/run_sparams.py
@@ -59,7 +59,7 @@ def main(input_file):
         '<script>',
         'const search=document.getElementById("search");',
         'search.addEventListener("input",()=>{',
-        ' const escape=s=>s.replace(/[.*+?^${}()|[\\]\\]/g,"\\$&");',
+        ' const escape=s=>s.replace(/[.*+?^${}()|[\\]\\\\]/g,"\\$&");',
         ' const re=new RegExp(escape(search.value)||".","i");',
         ' document.querySelectorAll(".plot").forEach(p=>{',
         '  p.style.display=re.test(p.dataset.title)?"":"none";',


### PR DESCRIPTION
## Summary
- fix escaping for special characters in sparams output page JS

## Testing
- `python -m py_compile scripts/run_sparams.py`


------
https://chatgpt.com/codex/tasks/task_e_684eb02566b8832a9391b87b3edf1fcc