### PR TITLE
Add chain task for cascading 4‑port networks

### DIFF
--- a/scripts/run_chain.py
+++ b/scripts/run_chain.py
@@ -1,0 +1,32 @@
+"""Cascade multiple 4-port Touchstone networks into a single network."""
+import argparse
+import skrf as rf
+
+
+def generate_chain(n: int, path: str):
+    """Cascade `n` identical 4-port networks from the given Touchstone file."""
+    if n < 1:
+        raise ValueError("n must be >= 1")
+    base = rf.Network(path)
+    if base.nports != 4:
+        raise ValueError("Touchstone must be a 4-port file")
+    chain = base
+    for _ in range(1, n):
+        next_net = rf.Network(path)
+        chain = rf.connect(chain, 2, next_net, 0, 2)
+    chain.write_touchstone('full_channel')
+
+
+def main(file_path: str, n: int):
+    generate_chain(n, file_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Generate cascaded 4-port network')
+    parser.add_argument('--file', required=True,
+                        help='Input 4-port Touchstone file')
+    parser.add_argument('--n', type=int, required=True,
+                        help='Number of sections in the chain')
+    args = parser.parse_args()
+    main(args.file, args.n)

--- a/task_config.yaml
+++ b/task_config.yaml
@@ -8,3 +8,6 @@ primes:
 sparams:
   venv_python: python
   script_path: scripts/run_sparams.py
+chain:
+  venv_python: python
+  script_path: scripts/run_chain.py

--- a/templates/task.html
+++ b/templates/task.html
@@ -11,6 +11,11 @@
     {% elif task_type == 'primes' %}
     <label class="form-label">N</label>
     <input type="number" name="n" class="form-control" min="2" placeholder="N" required>
+    {% elif task_type == 'chain' %}
+    <label class="form-label">Touchstone File</label>
+    <input type="file" name="file" class="form-control" required>
+    <label class="form-label mt-3">n</label>
+    <input type="number" name="n" class="form-control" min="1" value="1" required>
     {% elif task_type == 'sparams' %}
     <label class="form-label">Touchstone File</label>
       <input type="file" name="file" class="form-control" required>

--- a/user_routes.py
+++ b/user_routes.py
@@ -133,6 +133,35 @@ def submit_task(task_type):
         from tasks import run_task
         run_task.delay(new_task.id)
         return redirect(url_for('user.dashboard'))
+    elif task_type == 'chain':
+        uploaded = request.files.get('file')
+        if not uploaded or uploaded.filename == '':
+            flash('No file uploaded')
+            return redirect(url_for('user.task_detail', task_type=task_type))
+        n_val = request.form.get('n', type=int)
+        if not n_val or n_val < 1:
+            flash('Invalid n value')
+            return redirect(url_for('user.task_detail', task_type=task_type))
+        from werkzeug.utils import secure_filename
+        filename = secure_filename(uploaded.filename)
+        new_task = Task(
+            user_id=current_user.id,
+            task_type=task_type,
+            parameters=json.dumps({})
+        )
+        db.session.add(new_task)
+        db.session.commit()
+        output_dir = os.path.join(current_app.root_path, 'outputs', str(new_task.id))
+        os.makedirs(output_dir, exist_ok=True)
+        upload_path = os.path.join(output_dir, filename)
+        uploaded.save(upload_path)
+        params['file'] = filename
+        params['n'] = n_val
+        new_task.parameters = json.dumps(params)
+        db.session.commit()
+        from tasks import run_task
+        run_task.delay(new_task.id)
+        return redirect(url_for('user.dashboard'))
     else:
         abort(400)
     new_task = Task(


### PR DESCRIPTION
## Summary
- add `run_chain.py` script for cascading identical 4-port touchstone networks
- register new `chain` task in `task_config.yaml`
- allow upload of touchstone file and `n` for chain task
- show chain form option in `task.html`

## Testing
- `python scripts/run_chain.py --help`
- `python -m py_compile scripts/run_chain.py user_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_6854ba22d0e0832ab7acb06355f933ea