### PR TITLE
Fix cascade task form

### DIFF
--- a/templates/task.html
+++ b/templates/task.html
@@ -46,6 +46,15 @@
       plotSel.addEventListener('change', toggleOpts);
       toggleOpts();
     </script>
+    {% elif task_type == 'cascade' %}
+    <label class="form-label">N</label>
+    <input type="number" name="n" class="form-control" min="1" value="3" required>
+    <label class="form-label mt-2">Touchstone File</label>
+    <input type="file" name="file" class="form-control" required>
+    <div class="mt-3">
+      <label class="form-label">Remote IP (optional)</label>
+      <input type="text" name="ip" class="form-control" placeholder="192.168.x.x">
+    </div>
     {% endif %}
   </div>
   <button type="submit" class="btn btn-primary">Submit</button>

--- a/user_routes.py
+++ b/user_routes.py
@@ -133,6 +133,34 @@ def submit_task(task_type):
         from tasks import run_task
         run_task.delay(new_task.id)
         return redirect(url_for('user.dashboard'))
+    elif task_type == 'cascade':
+        uploaded = request.files.get('file')
+        if not uploaded or uploaded.filename == '':
+            flash('No file uploaded')
+            return redirect(url_for('user.task_detail', task_type=task_type))
+        from werkzeug.utils import secure_filename
+        filename = secure_filename(uploaded.filename)
+        new_task = Task(
+            user_id=current_user.id,
+            task_type=task_type,
+            parameters=json.dumps({})
+        )
+        db.session.add(new_task)
+        db.session.commit()
+        output_dir = os.path.join(current_app.root_path, 'outputs', str(new_task.id))
+        os.makedirs(output_dir, exist_ok=True)
+        upload_path = os.path.join(output_dir, filename)
+        uploaded.save(upload_path)
+        params['touchstone'] = filename
+        params['n'] = request.form.get('n', type=int)
+        ip = request.form.get('ip')
+        if ip:
+            params['ip'] = ip
+        new_task.parameters = json.dumps(params)
+        db.session.commit()
+        from tasks import run_task
+        run_task.delay(new_task.id)
+        return redirect(url_for('user.dashboard'))
     else:
         abort(400)
     new_task = Task(


### PR DESCRIPTION
## Summary
- handle new `cascade` task in the routes
- add form fields for the cascade application

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854bf9b31e4832aa494ccc470928fa4