### PR TITLE
Add output path log for cascade

### DIFF
--- a/scripts/cascade.py
+++ b/scripts/cascade.py
@@ -39,7 +39,9 @@ def run_cascade(n: int, touchstone_path: str, windows_ip: str | None) -> None:
         setup = circuit.create_setup(setup_type=circuit.SETUPS.NexximLNA)
         setup.props["SweepDefinition"]["Data"] = "LINC 0GHz 20GHz 2001"
         circuit.analyze(setup.name)
-        circuit.export_touchstone(output_file="full_channel.s4p")
+        output_path = os.path.join(os.path.dirname(cir_path), "full_channel.s4p")
+        circuit.export_touchstone(output_file=output_path)
+        print(f"Touchstone saved to {output_path}")
     finally:
         circuit.release_desktop(True, False)
 


### PR DESCRIPTION
## Summary
- log where `full_channel.s4p` Touchstone is exported

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854c4abcbac832a8f4d08765e5cb957