### PR TITLE
Add insertion loss app

### DIFF
--- a/scripts/get_insertiom_loss.py
+++ b/scripts/get_insertiom_loss.py
@@ -1,0 +1,54 @@
+"""Compute insertion loss and output an HTML preview.
+
+This script connects to a running AEDT instance and creates a simple
+transmission line. Users may specify the line length, dielectric constant
+(`dk`) and loss tangent (`df`). The resulting dB(S21) curve is plotted and
+saved to ``insertion_loss.png`` along with an ``index.html`` file that displays
+the image.
+"""
+import argparse
+import os
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from pyaedt import Circuit
+
+
+def main(length, dk, df):
+    circuit = Circuit(machine=os.environ['WINDOWS_IP'], port=50051)
+    try:
+        tline = circuit.modeler.components.create_component(
+            'a1', 'Ideal Distributed', 'TRLK_NX'
+        )
+        circuit.modeler.schematic.create_interface_port('p1', tline.pins[0].location)
+        circuit.modeler.schematic.create_interface_port('p2', tline.pins[1].location)
+        tline.parameters['P'] = length
+        tline.parameters['K'] = dk
+        tline.parameters['A'] = df
+        setup = circuit.create_setup(setup_type=circuit.SETUPS.NexximLNA)
+        setup.props['SweepDefinition']['Data'] = 'LINC 0.1GHz 3GHz 2001'
+        setup.analyze()
+        data = circuit.post.get_solution_data('dB(S21)')
+        y = data.data_real()
+        x = data.primary_sweep_values
+        plt.plot(x, y)
+        plt.xlabel('Frequency (Hz)')
+        plt.ylabel('dB(S21)')
+        plt.grid(True)
+        plt.tight_layout()
+        img_file = 'insertion_loss.png'
+        plt.savefig(img_file)
+        plt.close()
+        with open('index.html', 'w') as f:
+            f.write(f'<html><body><img src="{img_file}" alt="Insertion Loss"></body></html>')
+    finally:
+        circuit.release_desktop(True, False)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run insertion loss simulation.')
+    parser.add_argument('--length', required=True, help='Line length')
+    parser.add_argument('--dk', required=True, help='Dielectric constant')
+    parser.add_argument('--df', required=True, help='Loss tangent')
+    args = parser.parse_args()
+    main(args.length, args.dk, args.df)

--- a/task_config.yaml
+++ b/task_config.yaml
@@ -8,3 +8,6 @@ primes:
 sparams:
   venv_python: python
   script_path: scripts/run_sparams.py
+insertion_loss:
+  venv_python: python
+  script_path: scripts/get_insertiom_loss.py

--- a/templates/task.html
+++ b/templates/task.html
@@ -11,6 +11,13 @@
     {% elif task_type == 'primes' %}
     <label class="form-label">N</label>
     <input type="number" name="n" class="form-control" min="2" placeholder="N" required>
+    {% elif task_type == 'insertion_loss' %}
+    <label class="form-label">Length</label>
+    <input type="text" name="length" class="form-control" placeholder="e.g., 20mm" required>
+    <label class="form-label mt-2">Dk</label>
+    <input type="text" name="dk" class="form-control" placeholder="e.g., 4.2" required>
+    <label class="form-label mt-2">Df</label>
+    <input type="text" name="df" class="form-control" placeholder="e.g., 0.02" required>
     {% elif task_type == 'sparams' %}
     <label class="form-label">Touchstone File</label>
       <input type="file" name="file" class="form-control" required>

--- a/user_routes.py
+++ b/user_routes.py
@@ -105,6 +105,10 @@ def submit_task(task_type):
         params['depth'] = request.form.get('depth', type=int)
     elif task_type == 'primes':
         params['n'] = request.form.get('n', type=int)
+    elif task_type == 'insertion_loss':
+        params['length'] = request.form.get('length')
+        params['dk'] = request.form.get('dk')
+        params['df'] = request.form.get('df')
     elif task_type == 'sparams':
         uploaded = request.files.get('file')
         if not uploaded or uploaded.filename == '':


### PR DESCRIPTION
## Summary
- add `get_insertiom_loss.py` script for calculating insertion loss
- expose new task type via `task_config.yaml`
- allow users to input length, dk and df on the task page
- process those parameters in `user_routes`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854ed975c14832a92469afb7cdbd3b0