### PR TITLE
Add error html output on task failure

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -2,6 +2,7 @@
 import os
 import json
 import subprocess
+import html
 from datetime import datetime
 
 from config_utils import load_config
@@ -41,11 +42,25 @@ def run_task(self, task_id):
         cmd += [f'--{key}', str(value)]
 
     try:
-        # Run the external script
-        subprocess.check_call(cmd, cwd=output_dir)
-        status = 'SUCCESS'
-    except subprocess.CalledProcessError:
+        # Run the external script and capture output for error reporting
+        result = subprocess.run(
+            cmd, cwd=output_dir, capture_output=True, text=True
+        )
+        status = 'SUCCESS' if result.returncode == 0 else 'FAILURE'
+        if status == 'FAILURE':
+            error_file = os.path.join(output_dir, 'error.html')
+            with open(error_file, 'w') as f:
+                f.write('<html><body><pre>')
+                f.write(html.escape((result.stdout or '') + (result.stderr or '')))
+                f.write('</pre></body></html>')
+    except Exception as exc:
+        # Unexpected exceptions are also reported as FAILURE
         status = 'FAILURE'
+        error_file = os.path.join(output_dir, 'error.html')
+        with open(error_file, 'w') as f:
+            f.write('<html><body><pre>')
+            f.write(html.escape(str(exc)))
+            f.write('</pre></body></html>')
 
     # Generate result.json with list of output files and status
     files = os.listdir(output_dir)


### PR DESCRIPTION
## Summary
- capture stdout/stderr from scripts in `run_task`
- write the message to `error.html` when a task fails

## Testing
- `python -m py_compile tasks.py user_routes.py admin_routes.py flask_app.py models.py config_utils.py celery_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6854f581d028832a820bf688aa60ac6a