### PR TITLE
Add microstrip simulation task

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ celery -A celery_app.celery worker --loglevel=info --pool=solo
 - **Fractal**：輸入深度 `--depth`，於 `outputs/<task_id>/fractal.png` 產生 Sierpinski 三角形圖檔，並將檔案列表與狀態寫入 `result.json`
 - **Primes**：輸入上限 `--n`，於 `outputs/<task_id>/result.csv` 輸出所有小於 N 的質數
 - **Sparams**：上傳任意埠數的 Touchstone 檔案（副檔名 `.sNp`，`N` 為任意整數），於 `outputs/<task_id>/` 產生各組 S-parameter 圖檔與 `index.html`。`index.html` 中的搜尋框支援輸入正規表示式過濾檢視的圖檔
+- **Microstrip**：輸入厚度、介電常數、損耗正切、線寬、線長與掃描範圍，於 `outputs/<task_id>/` 產生 `s21.png` 與 `index.html`，瀏覽器可直接檢視 dB(S21) 曲線
 
 ## 管理者功能
 - 設定管理者帳號：手動在資料庫中將 `User.is_admin` 欄位設為 `True`

--- a/scripts/run_microstrip.py
+++ b/scripts/run_microstrip.py
@@ -1,0 +1,66 @@
+"""Run a microstrip simulation and output an HTML preview.
+
+This script uses PyAEDT ``Circuit`` to analyze a microstrip defined via a
+netlist. Users specify substrate thickness, relative permittivity, loss
+tangent, trace width, length and sweep range. After solving, the dB(S21)
+curve is plotted and saved to ``s21.png`` along with ``index.html`` that
+embeds the image.
+"""
+import argparse
+import os
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from pyaedt import Circuit
+
+
+def main(thickness, er, tand, width, length, sweep_range):
+    sweep_values = sweep_range.split(',')
+    if len(sweep_values) != 3:
+        raise ValueError('sweep_range must be "start,stop,points"')
+    start, stop, points = sweep_values
+
+    netlist = f"""
+.SUB Substrate MS( H={float(thickness)*1e-3} Er={er} TAND={tand} TANM=0 MSat=0 MRem=0 HU=0.025
++MET1=1.724138 T1=1.778e-05)
+
+A1 Port1 Port2 W={float(width)*1e-3} P={float(length)*1e-3} COMPONENT=TRL SUBSTRATE=Substrate
+"""
+    with open('micro_strip.cir', 'w') as f:
+        f.write(netlist)
+
+    circuit = Circuit(machine=os.environ['WINDOWS_IP'], port=50051)
+    try:
+        circuit.add_netlist_datablock('micro_strip.cir')
+        circuit.modeler.schematic.create_interface_port('Port1')
+        circuit.modeler.schematic.create_interface_port('Port2')
+        setup = circuit.create_setup(setup_type=circuit.SETUPS.NexximLNA)
+        setup.props['SweepDefinition']['Data'] = f"LINC {start} {stop} {points}"
+        circuit.analyze()
+        data = circuit.post.get_solution_data('dB(S21)')
+        x = data.primary_sweep_values
+        y = data.data_real()
+        plt.grid(True)
+        plt.xlabel(f"Frequency({data.units_sweeps})")
+        plt.ylabel('dB(S21)')
+        plt.plot(x, y)
+        img_file = 's21.png'
+        plt.tight_layout()
+        plt.savefig(img_file)
+        plt.close()
+        with open('index.html', 'w') as f:
+            f.write(f'<html><body><img src="{img_file}" alt="dB(S21)"></body></html>')
+    finally:
+        circuit.release_desktop(True, False)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Run microstrip simulation.')
+    parser.add_argument('--thickness', required=True, help='Substrate thickness in mm')
+    parser.add_argument('--er', required=True, help='Relative permittivity')
+    parser.add_argument('--tand', required=True, help='Loss tangent')
+    parser.add_argument('--width', required=True, help='Trace width in mm')
+    parser.add_argument('--length', required=True, help='Trace length in mm')
+    parser.add_argument('--sweep_range', required=True, help='start,stop,points e.g. 0GHz,20GHz,2001')
+    args = parser.parse_args()
+    main(args.thickness, args.er, args.tand, args.width, args.length, args.sweep_range)

--- a/task_config.yaml
+++ b/task_config.yaml
@@ -11,3 +11,6 @@ sparams:
 insertion_loss:
   venv_python: python
   script_path: scripts/get_insertiom_loss.py
+microstrip:
+  venv_python: python
+  script_path: scripts/run_microstrip.py

--- a/templates/task.html
+++ b/templates/task.html
@@ -18,6 +18,19 @@
     <input type="text" name="dk" class="form-control" placeholder="e.g., 4.2" required>
     <label class="form-label mt-2">Df</label>
     <input type="text" name="df" class="form-control" placeholder="e.g., 0.02" required>
+    {% elif task_type == 'microstrip' %}
+    <label class="form-label">Thickness (mm)</label>
+    <input type="text" name="thickness" class="form-control" required>
+    <label class="form-label mt-2">Er</label>
+    <input type="text" name="er" class="form-control" required>
+    <label class="form-label mt-2">TanD</label>
+    <input type="text" name="tand" class="form-control" required>
+    <label class="form-label mt-2">Width (mm)</label>
+    <input type="text" name="width" class="form-control" required>
+    <label class="form-label mt-2">Length (mm)</label>
+    <input type="text" name="length" class="form-control" required>
+    <label class="form-label mt-2">Sweep Range</label>
+    <input type="text" name="sweep_range" class="form-control" placeholder="0GHz,20GHz,2001" required>
     {% elif task_type == 'sparams' %}
     <label class="form-label">Touchstone File</label>
       <input type="file" name="file" class="form-control" required>

--- a/user_routes.py
+++ b/user_routes.py
@@ -109,6 +109,13 @@ def submit_task(task_type):
         params['length'] = request.form.get('length')
         params['dk'] = request.form.get('dk')
         params['df'] = request.form.get('df')
+    elif task_type == 'microstrip':
+        params['thickness'] = request.form.get('thickness')
+        params['er'] = request.form.get('er')
+        params['tand'] = request.form.get('tand')
+        params['width'] = request.form.get('width')
+        params['length'] = request.form.get('length')
+        params['sweep_range'] = request.form.get('sweep_range')
     elif task_type == 'sparams':
         uploaded = request.files.get('file')
         if not uploaded or uploaded.filename == '':


### PR DESCRIPTION
## Summary
- create `run_microstrip.py` script to run a PyAEDT microstrip analysis
- expose new `microstrip` task type in `task_config.yaml`
- support microstrip form fields and parameter handling in the web UI
- document the microstrip task

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6859ed9c2604832a8f6e510f4fa8e9cd