### PR TITLE
Add calculator

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,7 @@
     <a class="navbar-brand" href="{{ url_for('user.index') }}">Task Platform</a>
     <div class="ms-auto">
       {% if current_user.is_authenticated %}
+      <a class="btn btn-outline-primary me-2" href="{{ url_for('user.calculator') }}">Calculator</a>
       <span class="navbar-text me-3">{{ current_user.username }}</span>
       <a class="btn btn-outline-secondary" href="{{ url_for('user.logout') }}">Logout</a>
       {% else %}

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Calculator{% endblock %}
+{% block content %}
+<h1 class="mb-4">Calculator</h1>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Expression</label>
+    <input type="text" name="expression" class="form-control" value="{{ expression }}" required>
+  </div>
+  {% if result is not none %}
+  <div class="mb-3">
+    <label class="form-label">Result</label>
+    <input type="text" readonly class="form-control" value="{{ result }}">
+  </div>
+  {% endif %}
+  <button type="submit" class="btn btn-primary">Calculate</button>
+</form>
+{% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -23,6 +23,7 @@
   {% for key, cfg in configs.items() %}
   <a class="btn btn-primary me-3" href="{{ url_for('user.task_detail', task_type=key) }}">{{ key|capitalize }} App</a>
   {% endfor %}
+  <a class="btn btn-secondary" href="{{ url_for('user.calculator') }}">Calculator</a>
 </div>
 <div id="jobs-section">
   {% include '_jobs_table.html' %}


### PR DESCRIPTION
## Summary
- add safe calculator evaluation helpers
- implement `/calculator` route
- show calculator link in navbar and dashboard
- create calculator template

## Testing
- `python -m py_compile user_routes.py`
- `python -m py_compile flask_app.py admin_routes.py tasks.py models.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685a349a8280832a98e7b076ed417d03