### PR TITLE
Add Waitress server for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ flask-task-platform/
    pip install -r requirements.txt
    ```
 3. 編輯 `task_config.yaml`，將 `venv_python` 指向你的 Python 執行路徑（若使用虛擬環境為 `venv/bin/python` 或 `venv\Scripts\python.exe`）
-4. 啟動 Flask 應用：
+4. 啟動 Flask 應用（預設使用 Waitress 作為生產環境伺服器）：
    ```bash
    python flask_app.py
+   ```
+   若要使用內建開發伺服器，可設定 `FLASK_DEBUG=1`：
+   ```bash
+   FLASK_DEBUG=1 python flask_app.py
    ```
 5. 在瀏覽器開啟 `http://localhost:5000`，以管理者帳號登入
 6. 在 Dashboard 提交 `fractal` 或 `primes` 任務，完成後於列表下載結果檔案

--- a/flask_app.py
+++ b/flask_app.py
@@ -75,4 +75,11 @@ app.register_blueprint(admin_bp)
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Use built-in server in debug mode; otherwise start Waitress for production
+    if os.environ.get('FLASK_DEBUG'):  # development convenience
+        app.run(debug=True)
+    else:
+        from waitress import serve
+
+        port = int(os.environ.get('PORT', 5000))
+        serve(app, host='0.0.0.0', port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Pillow>=8.0.1
 matplotlib>=3.0
 scikit-rf>=0.29
 Flask-Executor>=1.0.0
+waitress>=2.1.2


### PR DESCRIPTION
## Summary
- switch to Waitress when running in production
- add Waitress dependency
- document Waitress usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68672cea627c832a9ec1001bd2236211