### PR TITLE
Add reload.bat script with IP display

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ flask-task-platform/
    ```bash
    FLASK_DEBUG=1 python flask_app.py
    ```
+   Windows 使用者也可執行 `reoload.bat`，
+   在啟動服務的同時顯示本機 IP 供其他裝置連線。
 5. 在瀏覽器開啟 `http://localhost:5000`，以管理者帳號登入
 6. 在 Dashboard 提交 `fractal` 或 `primes` 任務，完成後於列表下載結果檔案
 

--- a/reoload.bat
+++ b/reoload.bat
@@ -1,0 +1,10 @@
+@echo off
+set PORT=5000
+for /f "tokens=2 delims=:" %%A in ('ipconfig ^| findstr /R /C:"IPv4 Address"') do (
+    set IP=%%A
+    goto :gotip
+)
+:gotip
+set IP=%IP:~1%
+echo Server will be available at http://%IP%:%PORT%
+python flask_app.py


### PR DESCRIPTION
## Summary
- add `reoload.bat` for Windows users to start the server
- mention `reoload.bat` in README for showing the local IP

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68699a01caec832aabe6976d6abfac2a