### PR TITLE
Fix tasks import

### DIFF
--- a/service/user_routes.py
+++ b/service/user_routes.py
@@ -139,7 +139,7 @@ def submit_task(task_type):
             params['operation'] = request.form.get('operation', 'db')
         new_task.parameters = json.dumps(params)
         db.session.commit()
-        from tasks import schedule_task
+        from .tasks import schedule_task
         schedule_task(new_task.id)
         return redirect(url_for('user.dashboard'))
     else:
@@ -151,7 +151,7 @@ def submit_task(task_type):
     )
     db.session.add(new_task)
     db.session.commit()
-    from tasks import schedule_task
+    from .tasks import schedule_task
     schedule_task(new_task.id)
     return redirect(url_for('user.dashboard'))
 


### PR DESCRIPTION
## Summary
- fix incorrect import of `schedule_task`

## Testing
- `python service/flask_app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6869f90f5728832a986b51a4680bdf26