### PR TITLE
Improve login layout

### DIFF
--- a/service/templates/login.html
+++ b/service/templates/login.html
@@ -1,17 +1,27 @@
 {% extends 'base.html' %}
+
 {% block title %}Login{% endblock %}
+
 {% block content %}
-<h1 class="mb-4">Login</h1>
-<img src="{{ url_for('static', filename='images/login page.jpg') }}" alt="Login image" class="img-fluid mb-4">
-<form method="post" action="{{ url_for('user.login') }}">
-  <div class="mb-3">
-    <label class="form-label">Username</label>
-    <input type="text" name="username" class="form-control" required>
+<div class="row">
+  <div class="col-md-6 mb-4 mb-md-0">
+    <img src="{{ url_for('static', filename='images/login page.jpg') }}" alt="Login image" class="img-fluid">
   </div>
-  <div class="mb-3">
-    <label class="form-label">Password</label>
-    <input type="password" name="password" class="form-control" required>
+  <div class="col-md-6 d-flex align-items-center">
+    <div class="w-100">
+      <h1 class="mb-4 text-center">Login</h1>
+      <form method="post" action="{{ url_for('user.login') }}">
+        <div class="mb-3">
+          <label class="form-label">Username</label>
+          <input type="text" name="username" class="form-control" required>
+        </div>
+        <div class="mb-3">
+          <label class="form-label">Password</label>
+          <input type="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Login</button>
+      </form>
+    </div>
   </div>
-  <button type="submit" class="btn btn-primary">Login</button>
-</form>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- move login form into a right-aligned column
- display the login image to the left

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5bc6dcf4832a9277c238ee803280