### PR TITLE
Fix SQLAlchemy deprecation warning

### DIFF
--- a/service/flask_app.py
+++ b/service/flask_app.py
@@ -54,7 +54,7 @@ login_manager.init_app(app)
 
 @login_manager.user_loader
 def load_user(user_id):
-    return User.query.get(int(user_id))
+    return db.session.get(User, int(user_id))
 
 
 with app.app_context():

--- a/service/tasks.py
+++ b/service/tasks.py
@@ -15,7 +15,7 @@ def run_task(task_id):
     """Execute a user-submitted script in a virtual environment."""
     # Use application context when running in a background thread
     with app.app_context():
-        task = Task.query.get(task_id)
+        task = db.session.get(Task, task_id)
         if not task:
             return
 


### PR DESCRIPTION
## Summary
- update Flask user loader to use `db.session.get`
- use new `Session.get` API in background task runner

## Testing
- `python -m py_compile service/flask_app.py service/tasks.py`
- `python -m py_compile service/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686a60321704832a8cd3c3ab127ec79d