### PR TITLE
Fix HTML template braces

### DIFF
--- a/apps/layer_viewer/runner.py
+++ b/apps/layer_viewer/runner.py
@@ -8,34 +8,34 @@ HTML_TEMPLATE = """
 <!DOCTYPE html>
 <html>
 <head>
-<meta charset="UTF-8">
+<meta charset=\"UTF-8\">
 <title>Layer Viewer</title>
 <style>
-.container{display:flex;max-width:800px;margin:auto;}
-#layers{width:30%;padding:10px;}
-#viewer{width:70%;padding:10px;}
-#layerSelect{width:100%;height:200px;}
-img{max-width:100%;height:auto;}
+.container{{display:flex;max-width:800px;margin:auto;}}
+#layers{{width:30%;padding:10px;}}
+#viewer{{width:70%;padding:10px;}}
+#layerSelect{{width:100%;height:200px;}}
+img{{max-width:100%;height:auto;}}
 </style>
 </head>
 <body>
-<div class="container">
-  <div id="layers">
-    <select id="layerSelect" size="10">
+<div class=\"container\">
+  <div id=\"layers\">
+    <select id=\"layerSelect\" size=\"10\">
       {options}
     </select>
   </div>
-  <div id="viewer">
-    <img id="layerImage" src="{first_img}" alt="{first_layer}">
+  <div id=\"viewer\">
+    <img id=\"layerImage\" src=\"{first_img}\" alt=\"{first_layer}\">
   </div>
 </div>
 <script>
 const sel = document.getElementById('layerSelect');
 const img = document.getElementById('layerImage');
-sel.addEventListener('change', () => {
+sel.addEventListener('change', () => {{
   img.src = sel.value + '.png';
   img.alt = sel.value;
-});
+}});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- escape braces in the Layer Viewer HTML template so `.format()` doesn't fail

## Testing
- `python -m py_compile apps/layer_viewer/runner.py`

------
https://chatgpt.com/codex/tasks/task_e_686c33b3c094832a8509b0353d9d1c6d