### PR TITLE
Fix layer viewer zoom reset

### DIFF
--- a/apps/layer_viewer/runner.py
+++ b/apps/layer_viewer/runner.py
@@ -76,9 +76,8 @@ let scale = 1;
 sel.addEventListener('change', () => {{
   img.src = sel.value + '.png';
   img.alt = sel.value;
-  scale = 1;
-  img.style.transform = `scale(1)`;
-  img.style.transformOrigin = 'center center';
+  // maintain current zoom level and position when switching layers
+  img.style.transform = `scale(${{scale}})`;
 }});
 
 viewer.addEventListener('wheel', (e) => {{


### PR DESCRIPTION
## Summary
- keep image scale and origin when changing layers in the layer viewer

## Testing
- `python -m py_compile apps/layer_viewer/runner.py`

------
https://chatgpt.com/codex/tasks/task_e_686c7886e398832a9f1a99623dc97f62