### PR TITLE
Display all Layer Viewer output files

### DIFF
--- a/service/templates/_jobs_table.html
+++ b/service/templates/_jobs_table.html
@@ -17,12 +17,11 @@
       <td>{{ item.task.create_time.strftime('%Y-%m-%d %H:%M:%S') }}</td>
       <td>
         {% if item.html_file %}
-        <a class="link-primary" href="{{ url_for('user.view_file', task_id=item.task.id, filename=item.html_file) }}">{{ item.html_file }}</a>
-        {% else %}
-          {% for filename in item.files %}
-          <a class="link-primary" href="{{ url_for('user.download_file', task_id=item.task.id, filename=filename) }}">{{ filename }}</a><br>
-          {% endfor %}
+        <a class="link-primary" href="{{ url_for('user.view_file', task_id=item.task.id, filename=item.html_file) }}">{{ item.html_file }}</a><br>
         {% endif %}
+        {% for filename in item.files %}
+        <a class="link-primary" href="{{ url_for('user.download_file', task_id=item.task.id, filename=filename) }}">{{ filename }}</a><br>
+        {% endfor %}
       </td>
       <td>
         <form method="post" action="{{ url_for('user.delete_task', task_id=item.task.id) }}" class="d-inline" onsubmit="return confirm('Delete this task?');">

--- a/service/user_routes.py
+++ b/service/user_routes.py
@@ -80,9 +80,9 @@ def dashboard():
     tasks_data = []
     for t in tasks_query:
         files = json.loads(t.result_files) if t.result_files else []
-        if t.task_type == 'layer_viewer':
-            files = [f for f in files if not f.lower().endswith('.csv') and not f.lower().endswith('.aedb.zip')]
         html_file = next((f for f in files if f.lower().endswith('.html')), None)
+        if html_file:
+            files = [f for f in files if f != html_file]
         tasks_data.append({'task': t, 'files': files, 'html_file': html_file})
     return render_template('dashboard.html', tasks=tasks_data, configs=configs)
 
@@ -102,9 +102,9 @@ def dashboard_jobs():
     tasks_data = []
     for t in tasks_query:
         files = json.loads(t.result_files) if t.result_files else []
-        if t.task_type == 'layer_viewer':
-            files = [f for f in files if not f.lower().endswith('.csv') and not f.lower().endswith('.aedb.zip')]
         html_file = next((f for f in files if f.lower().endswith('.html')), None)
+        if html_file:
+            files = [f for f in files if f != html_file]
         tasks_data.append({'task': t, 'files': files, 'html_file': html_file})
     return render_template('_jobs_table.html', tasks=tasks_data, configs=configs)
 


### PR DESCRIPTION
## Summary
- keep CSV and AEDB zip results for Layer Viewer tasks
- show HTML viewer plus download links for all files in dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc2498c44832a9c48421dcd6d38bb