### PR TITLE
Filter output files for layer viewer

### DIFF
--- a/apps/layer_viewer/config.yaml
+++ b/apps/layer_viewer/config.yaml
@@ -4,3 +4,7 @@ parameters:
   file:
     label: BRD File
     type: file
+result_keep:
+  - index.html
+  - '*.xlsx'
+  - '*.aedb.zip'

--- a/service/config_utils.py
+++ b/service/config_utils.py
@@ -27,6 +27,7 @@ def load_config(enabled_only: bool = True):
             "script_path": script_rel,
             "params_def": cfg.get("parameters", {}),
             "metadata": info.get("metadata", {}),
+            "result_keep": cfg.get("result_keep"),
         }
     return configs
 

--- a/service/tasks.py
+++ b/service/tasks.py
@@ -3,6 +3,7 @@ import os
 import json
 import subprocess
 import html
+import fnmatch
 from datetime import datetime
 
 from .config_utils import load_config
@@ -74,6 +75,12 @@ def run_task(task_id):
 
         # Generate result.json with list of output files and status
         files = os.listdir(output_dir)
+        keep_patterns = task_conf.get("result_keep")
+        if keep_patterns:
+            kept = set()
+            for pat in keep_patterns:
+                kept.update(fnmatch.filter(files, pat))
+            files = sorted(kept)
         result = {'files': files, 'status': status}
         with open(os.path.join(output_dir, 'result.json'), 'w') as f:
             json.dump(result, f)


### PR DESCRIPTION
## Summary
- add optional `result_keep` config for plugins
- filter output files in task runner based on config
- specify visible results for layer viewer

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_686cdc1efedc832aa733924d23e194a0