### PR TITLE
Add draggable app grid on dashboard

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -33,3 +33,10 @@ class Task(db.Model):
     start_time = db.Column(db.DateTime)
     end_time = db.Column(db.DateTime)
     archived = db.Column(db.Boolean, default=False, nullable=False)
+
+
+class AppLayout(db.Model):
+    """Per-user application layout information."""
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), primary_key=True)
+    layout = db.Column(db.Text, nullable=False)
+    user = db.relationship('User', backref=db.backref('app_layout', uselist=False))

--- a/service/static/css/style.css
+++ b/service/static/css/style.css
@@ -19,3 +19,23 @@ th, td {
     color: red;
     list-style: none;
 }
+
+#app-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.app-card {
+    padding: 1rem;
+    border-radius: 0.5rem;
+    cursor: move;
+    position: relative;
+    text-align: center;
+    border: 1px solid #ccc;
+}
+
+.row-color-0 { background-color: #e3f2fd; }
+.row-color-1 { background-color: #e8f5e9; }
+.row-color-2 { background-color: #fff3cd; }
+.row-color-3 { background-color: #f8d7da; }

--- a/service/templates/dashboard.html
+++ b/service/templates/dashboard.html
@@ -19,11 +19,44 @@
 </script>
 {% endif %}
 <h2>Submit a new task</h2>
-<div class="mb-4">
-  {% for key, cfg in configs.items() %}
-  <a class="btn btn-primary me-3" href="{{ url_for('user.task_detail', task_type=key) }}">{{ cfg.metadata.name or key|capitalize }} App</a>
-  {% endfor %}
-</div>
+<div id="app-grid" class="mb-4"></div>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+  const apps = {{ ordered_apps|tojson }};
+  const grid = document.getElementById('app-grid');
+  function renderGrid() {
+    grid.innerHTML = '';
+    apps.forEach((item) => {
+      const card = document.createElement('div');
+      card.className = 'app-card';
+      card.dataset.name = item.name;
+      card.innerHTML = `<a href="${item.url}" class="stretched-link">${item.display} App</a>`;
+      grid.appendChild(card);
+    });
+    colorRows();
+  }
+  function colorRows(){
+    const cols = getComputedStyle(grid).gridTemplateColumns.split(' ').length;
+    const classes = ['row-color-0','row-color-1','row-color-2','row-color-3'];
+    Array.from(grid.children).forEach((el,i)=>{
+      classes.forEach(c=>el.classList.remove(c));
+      const row = Math.floor(i/cols)%classes.length;
+      el.classList.add(classes[row]);
+    });
+  }
+  function saveOrder(){
+    const order = Array.from(grid.children).map(el=>el.dataset.name);
+    fetch('{{ url_for('user.save_layout') }}',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({layout:order})
+    });
+    colorRows();
+  }
+  new Sortable(grid,{animation:150,onEnd:saveOrder});
+  window.addEventListener('resize',colorRows);
+  renderGrid();
+</script>
 <div id="jobs-section">
   {% include '_jobs_table.html' %}
 </div>


### PR DESCRIPTION
## Summary
- store per-user app layout in new `AppLayout` table
- load and persist app order on dashboard
- provide UI to drag apps using Sortable.js
- color each row in the grid

## Testing
- `python -m py_compile service/*.py`
- `pip install flask`
- `python service/flask_app.py` *(fails: ModuleNotFoundError: No module named 'flask_executor')*

------
https://chatgpt.com/codex/tasks/task_e_686ce0f63a2c832ab802530d95721244