### PR TITLE
Fix missing AEDB error in update_stackup

### DIFF
--- a/apps/update_stackup/runner.py
+++ b/apps/update_stackup/runner.py
@@ -78,7 +78,12 @@ def main(aedb_zip, xlsx_file):
     with tempfile.TemporaryDirectory() as tmp:
         with zipfile.ZipFile(aedb_zip) as z:
             z.extractall(tmp)
-        aedb_dir = next(p for p in os.listdir(tmp) if p.endswith('.aedb'))
+        aedb_dirs = [p for p in os.listdir(tmp) if p.endswith('.aedb')]
+        if not aedb_dirs:
+            raise FileNotFoundError(
+                'No .aedb folder found in the provided zip archive.'
+            )
+        aedb_dir = aedb_dirs[0]
         aedb_path = os.path.join(tmp, aedb_dir)
         shutil.copy(xlsx_file, os.path.join(tmp, 'stackup.xlsx'))
         apply_xlsx(os.path.join(tmp, 'stackup.xlsx'), aedb_path)


### PR DESCRIPTION
## Summary
- raise a clear error if no `.aedb` folder exists in the uploaded ZIP

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871ccd167fc832aa4684607674250b9