### PR TITLE
Fix readpcb AEDB output path

### DIFF
--- a/apps/readpcb/runner.py
+++ b/apps/readpcb/runner.py
@@ -54,7 +54,9 @@ def main(brd_file):
     edb_name = 'board.aedb'
     edb = Edb(brd_file, edbversion='2024.1')
     export_stackup(edb, 'stackup.xlsx')
-    edb.save_edb()
+    # Save the project inside the current working directory so it can be
+    # included in the output files instead of writing next to the source ``.brd``.
+    edb.save_edb_as(edb_name)
     edb.close_edb()
     zip_name = 'board_aedb.zip'
     with zipfile.ZipFile(zip_name, 'w', zipfile.ZIP_DEFLATED) as z:


### PR DESCRIPTION
## Summary
- ensure the ReadPCB task saves the generated AEDB inside the task output folder

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ce930864832a822a481c43126302