### PR TITLE
Remove App label on dashboard buttons

### DIFF
--- a/service/templates/dashboard.html
+++ b/service/templates/dashboard.html
@@ -30,7 +30,7 @@
     card.className = 'app-card';
     card.dataset.name = item.name;
     card.href = item.url;
-    card.textContent = `${item.display} App`;
+    card.textContent = item.display;
     return card;
   }
 


### PR DESCRIPTION
## Summary
- simplify dashboard app button text by removing the word "App"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871ee5c369c832ab11fb8ab6b1efaa8