### PR TITLE
Add AEDT version selector for ReadPCB

### DIFF
--- a/apps/readpcb/config.yaml
+++ b/apps/readpcb/config.yaml
@@ -4,3 +4,12 @@ parameters:
   brd:
     label: BRD File
     type: file
+  edbversion:
+    label: AEDT Version
+    type: select
+    options:
+      "2024.1": "2024.1"
+      "2024.2": "2024.2"
+      "2025.1": "2025.1"
+      "2025.2": "2025.2"
+    default: "2025.1"

--- a/apps/readpcb/runner.py
+++ b/apps/readpcb/runner.py
@@ -92,9 +92,9 @@ tr:nth-child(odd) {{
         f.write(html)
 
 
-def main(brd_file):
+def main(brd_file, edb_version):
     edb_name = 'board.aedb'
-    edb = Edb(brd_file, edbversion='2024.1')
+    edb = Edb(brd_file, edbversion=edb_version)
     export_stackup(edb, 'stackup.xlsx')
     # Save the project inside the current working directory so it can be
     # included in the output files instead of writing next to the source ``.brd``.
@@ -114,5 +114,6 @@ def main(brd_file):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Convert BRD to AEDB and export stackup.')
     parser.add_argument('--brd', required=True, help='Input BRD file')
+    parser.add_argument('--edbversion', default='2025.1', help='AEDT version')
     args = parser.parse_args()
-    main(args.brd)
+    main(args.brd, args.edbversion)

--- a/apps/readpcb/template.html
+++ b/apps/readpcb/template.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block title %}ReadPCB App{% endblock %}
+{% block content %}
+<h1 class="mb-4">ReadPCB Application</h1>
+<form action="{{ url_for('user.submit_task', task_type='readpcb') }}" method="post" class="mt-3" enctype="multipart/form-data">
+  <div class="mb-3">
+    <label class="form-label">BRD File</label>
+    <input type="file" name="brd" class="form-control" required>
+    <label class="form-label mt-2">AEDT Version</label>
+    <select name="edbversion" id="edbversion" class="form-select">
+      <option value="2024.1">2024.1</option>
+      <option value="2024.2">2024.2</option>
+      <option value="2025.1" selected>2025.1</option>
+      <option value="2025.2">2025.2</option>
+    </select>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+<script>
+const sel = document.getElementById('edbversion');
+const key = 'readpcb-edbversion';
+const saved = localStorage.getItem(key);
+if (saved) {
+  sel.value = saved;
+}
+sel.addEventListener('change', () => {
+  localStorage.setItem(key, sel.value);
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow choosing AEDT version in ReadPCB task
- support `--edbversion` in ReadPCB runner
- remember selected version in the browser

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6871efc707d8832aa227d6f90ffce351