### PR TITLE
Add version option for UpdateStackup

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ flask-task-platform/
 - **Sparams**：上傳任意埠數的 Touchstone 檔案（副檔名 `.sNp`，`N` 為任意整數），於 `outputs/<task_id>/` 產生各組 S-parameter 圖檔與 `index.html`。`index.html` 中的搜尋框支援輸入正規表示式過濾檢視的圖檔
 - **Microstrip**：模擬微帶傳輸線並輸出 `microstrip.png`，需要安裝 `pyaedt` 並連線 ANSYS Electronics Desktop
 - **ReadPCB**：上傳 `.brd` 產生壓縮後的 AEDB 與 `stackup.xlsx`，`result.html` 顯示堆疊表
-- **UpdateStackup**：上傳 AEDB 壓縮檔與修改後的 `xlsx`，回傳更新後的 AEDB 壓縮檔並以 HTML 呈現新的堆疊表
+- **UpdateStackup**：上傳 AEDB 壓縮檔與修改後的 `xlsx`，可選擇 AEDT 版本，回傳更新後的 AEDB 壓縮檔並以 HTML 呈現新的堆疊表
 
 ## 管理者功能
 - 設定管理者帳號：手動在資料庫中將 `User.is_admin` 欄位設為 `True`

--- a/apps/update_stackup/config.yaml
+++ b/apps/update_stackup/config.yaml
@@ -7,3 +7,12 @@ parameters:
   xlsx:
     label: Stackup Excel
     type: file
+  version:
+    label: AEDT Version
+    type: select
+    options:
+      "2024.1": "2024.1"
+      "2024.2": "2024.2"
+      "2025.1": "2025.1"
+      "2025.2": "2025.2"
+    default: "2025.1"

--- a/apps/update_stackup/runner.py
+++ b/apps/update_stackup/runner.py
@@ -129,7 +129,7 @@ tr:nth-child(odd) {{
         f.write(html)
 
 
-def main(aedb_zip, xlsx_file):
+def main(aedb_zip, xlsx_file, version):
     with tempfile.TemporaryDirectory() as tmp:
         with zipfile.ZipFile(aedb_zip) as z:
             z.extractall(tmp)
@@ -141,7 +141,7 @@ def main(aedb_zip, xlsx_file):
         aedb_dir = aedb_dirs[0]
         aedb_path = os.path.join(tmp, aedb_dir)
         shutil.copy(xlsx_file, os.path.join(tmp, 'stackup.xlsx'))
-        apply_xlsx(os.path.join(tmp, 'stackup.xlsx'), aedb_path)
+        apply_xlsx(os.path.join(tmp, 'stackup.xlsx'), aedb_path, version)
         export_stackup(Edb(aedb_path, edbversion='2024.1'), os.path.join(tmp, 'updated.xlsx'))
         output_zip = 'updated_aedb.zip'
         with zipfile.ZipFile(output_zip, 'w', zipfile.ZIP_DEFLATED) as out:
@@ -159,5 +159,6 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Update stackup from Excel file.')
     parser.add_argument('--aedb_zip', required=True, help='Zipped AEDB')
     parser.add_argument('--xlsx', required=True, help='Stackup Excel file')
+    parser.add_argument('--version', default='2025.1', help='AEDT version')
     args = parser.parse_args()
-    main(args.aedb_zip, args.xlsx)
+    main(args.aedb_zip, args.xlsx, args.version)


### PR DESCRIPTION
## Summary
- let users pick AEDT version when updating stackup
- pass selected version to `apply_xlsx`
- document version option

## Testing
- `python -m py_compile apps/update_stackup/runner.py`

------
https://chatgpt.com/codex/tasks/task_e_68733ef00008832a8b3ed598f7e2774d