### PR TITLE
Limit UpdateStackup output

### DIFF
--- a/apps/update_stackup/config.yaml
+++ b/apps/update_stackup/config.yaml
@@ -16,3 +16,5 @@ parameters:
       "2025.1": "2025.1"
       "2025.2": "2025.2"
     default: "2025.1"
+result_keep:
+  - updated_aedb.zip


### PR DESCRIPTION
## Summary
- keep only `updated_aedb.zip` for UpdateStackup jobs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68734ab8f62c832ab8d1fd09bccc544a