### PR TITLE
Fix deletion error

### DIFF
--- a/service/user_routes.py
+++ b/service/user_routes.py
@@ -217,7 +217,10 @@ def delete_task(task_id):
     output_dir = os.path.join(base_dir, 'outputs', str(task_id))
     if os.path.exists(output_dir):
         import shutil
-        shutil.rmtree(output_dir)
+        try:
+            shutil.rmtree(output_dir)
+        except Exception as exc:  # pragma: no cover - best effort cleanup
+            current_app.logger.warning("Failed to remove %s: %s", output_dir, exc)
     task.archived = True
     task.result_files = json.dumps([])
     db.session.commit()


### PR DESCRIPTION
## Summary
- handle errors when removing task output directory to avoid 500 errors

## Testing
- `python -m py_compile service/user_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68734cdf5494832aae877c355edf2c97