### PR TITLE
Limit ReadPCB outputs

### DIFF
--- a/apps/readpcb/config.yaml
+++ b/apps/readpcb/config.yaml
@@ -13,3 +13,6 @@ parameters:
       "2025.1": "2025.1"
       "2025.2": "2025.2"
     default: "2025.1"
+result_keep:
+  - board_aedb.zip
+  - stackup.xlsx


### PR DESCRIPTION
## Summary
- filter ReadPCB results so only board_aedb.zip and stackup.xlsx remain

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68736529b30c832a88939910d397ef02